### PR TITLE
try replace last day parking full time with same day last week

### DIFF
--- a/miniprogram/components/commute/commute.js
+++ b/miniprogram/components/commute/commute.js
@@ -4,6 +4,7 @@ import {
 } from "../../pages/router";
 import {
   fetchLastParkingFullTime,
+  fetchLastWeekParkingFullTime,
   fetchParkingSpace,
   recordParkingFull
 } from "../../repository/dashboardRepo"
@@ -49,9 +50,9 @@ Component({
     },
 
     fetchParkingSpacePredictionData() {
-      fetchLastParkingFullTime().then(res => {
+      fetchLastWeekParkingFullTime().then(res => {
         let lastParkingFullTimeStr = ""
-        let dayStrPrefix = (new Date()).getDay() == 1 ? '上周五' : '昨日'
+        let dayStrPrefix = '上周今日'
         const showParkingFullTip = res != null
         if (res) {
           const lastParkingFullTime = (new Date(res)).hhmm();

--- a/miniprogram/repository/dashboardRepo.js
+++ b/miniprogram/repository/dashboardRepo.js
@@ -271,6 +271,26 @@ export function fetchLastParkingFullTime() {
   });
 }
 
+export function fetchLastWeekParkingFullTime() {
+  const now = new Date();
+  const lastWeekParkingFullDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  lastWeekParkingFullDate.setHours(0, 0, 0, 0);
+
+  return new Promise((resolve, reject) => {
+    cloudCall(db.collection("parking-full").where({
+      date: _.gte(lastWeekParkingFullDate.getTime())
+    }).get(), "fetchLastWeekParkingFullTime").then(res => {
+      if (!res || res.length === 0) {
+        resolve(null);
+        return;
+      }
+
+      let lastWeekParkingFull = res[0].full;
+      resolve(lastWeekParkingFull);
+    });
+  });
+}
+
 export function recordParkingFull(full = null, left20 = null, left10 = null) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);


### PR DESCRIPTION
I wonder if that makes more sense to replace the parking full time of last working day with same day last week, since:
- Current way provides last Friday data for next Monday, where we know Monday is the most busy day and Friday is the least

I see somewhere you have a cloudfunction to 'predict' the parking full time with last week data, no sure if there is anything to do with this change.

This also brings in more things to consider like: a week after holiday like National Holiday, the last week data would be very different from this week. I think this could be a further to-do.